### PR TITLE
A leading 0 means the value will be interpreted as octal representation

### DIFF
--- a/lib/iban-tools/conversion.rb
+++ b/lib/iban-tools/conversion.rb
@@ -5,7 +5,7 @@ module IBANTools
       config = load_config country_code
 
       bban = config.map do |key, value|
-        value[1] % data[key.to_sym]
+        value[1] % data[key.to_sym].to_i
       end.join('')
 
       check_digits = "%02d" % checksum(country_code, bban)

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -15,6 +15,12 @@ module IBANTools
             local2iban('DE', :blz => '32050000', :account_number => '46463055')
           iban.should be_valid_check_digits
         end
+        it 'returns valid IBAN, when account starts with zero (octal)' do
+          iban = Conversion.
+            local2iban('DE', :blz => '32050000', :account_number => '06463055')
+          iban.code.should == "DE65320500000006463055"
+          iban.should be_valid_check_digits
+        end
       end
     end
 


### PR DESCRIPTION
To avoid this, just call to_i before %
