### PR TITLE
Fixed bundler deprecation warnings, because "source :rubygems" is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
fixed bundler source due deprecation warnings:

> > The source :rubygems is deprecated because HTTP requests are insecure.
> > Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
