### PR TITLE
Fixed rspec deprecations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ end
 require 'iban-tools'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
- fixed rspec deprecation warning about non explicitly defined "should"-matcher
- removed rspec deprecation warning about "treat_symbols_as_metadata_keys_with_true_values".

> > Deprecation Warnings:
> > RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.
