### PR TITLE
Drop .rb suffixes of files in require

### DIFF
--- a/lib/iban-tools.rb
+++ b/lib/iban-tools.rb
@@ -22,6 +22,6 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #++
 
-require 'iban-tools/conversion.rb'
-require 'iban-tools/iban.rb'
-require 'iban-tools/iban_rules.rb'
+require 'iban-tools/conversion'
+require 'iban-tools/iban'
+require 'iban-tools/iban_rules'


### PR DESCRIPTION
This syntax detail is not necessary.