### PR TITLE
Add Vatican City rules

### DIFF
--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -317,6 +317,10 @@
   reserved: 1!c
   account_number: 16!c
 
+'VA':
+  bank_code: 3!n
+  account_number: 15!n
+
 'VG':
   bank_code: 4!c
   account_number: 16!n

--- a/lib/iban-tools/rules.yml
+++ b/lib/iban-tools/rules.yml
@@ -249,12 +249,12 @@
   # Montenegro
   length: 22
   bban_pattern: '\d{18}'
-  
+
 'MG':
   # Madagascar
   length: 27
   bban_pattern: '\d{23}'
-  
+
 'MK':
   # Macedonia
   length: 19
@@ -369,6 +369,11 @@
   # Ukraine
   length: 29
   bban_pattern: '\d{25}'
+
+'VA':
+  # Vatican City
+  length: 22
+  bban_pattern: '\d{18}'
 
 'VG':
   # Virgin Islands

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -66,6 +66,7 @@ module IBANTools
       'SM86U0322509800000000270100' => {check_char: 'U', bank_code: '3225', branch_code: '9800', account_number: '270100'},
       'TN5914207207100707129648' => {bank_code: '14', branch_code: '207', account_number: '207100707129648'},
       'TR330006100519786457841326' => {bank_code: '61', reserved: '0', account_number: '519786457841326'},
+      'VA59001123000012345678' => {bank_code: '1', account_number: '123000012345678'},
       'VG96VPVG0000012345678901' => {bank_code: 'VPVG', account_number: '12345678901'},
     }
 

--- a/spec/iban-tools/iban_spec.rb
+++ b/spec/iban-tools/iban_spec.rb
@@ -174,7 +174,8 @@ module IBANTools
         "XK051212012345678906",
         "SC52BAHL01031234567890123456USD",
         "PS92PALS000000000400123456702",
-        "CR05015202001026284066"
+        "CR05015202001026284066",
+        "VA59001123000012345678"
       ].each do |iban_code|
         describe iban_code do
           it "should be valid" do


### PR DESCRIPTION
Added Vatican City to rules and conversion rules, taken from Wikipedia [IBAN formats by country](https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country).