### PR TITLE
Speed up IBAN#prettify

### DIFF
--- a/lib/iban-tools/iban.rb
+++ b/lib/iban-tools/iban.rb
@@ -89,7 +89,7 @@ module IBANTools
 
     # The IBAN code in a human-readable format
     def prettify
-      @code.gsub(/(.{4})/, '\1 ').strip
+      @code.scan(/.{1,4}/).join(' ').strip
     end
   end
 end


### PR DESCRIPTION
Replacing our own implementation with library code, I found that our implementation was slightly faster (upto 10%, more if you don't strip):

```
require 'benchmark'

n = 500_000

Benchmark.bmbm do |x|
  x.report('gsub') { n.times do 'DE02120300000000202051'.gsub(/(.{4})/, '\1 ').strip end }
  x.report('scan') { n.times do 'DE02120300000000202051'.scan(/.{1,4}/).join(' ').strip end }
end
```

```
Rehearsal ----------------------------------------
gsub   0.099721   0.000681   0.100402 (  0.100422)
scan   0.093662   0.000809   0.094471 (  0.094668)
------------------------------- total: 0.194873sec

           user     system      total        real
gsub   0.099239   0.001079   0.100318 (  0.100424)
```