### PR TITLE
Support additional country conversions (BR, CR, EG, SV, UA, XK)

### DIFF
--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -352,3 +352,9 @@
 'VG':
   bank_code: 4!c
   account_number: 16!n
+
+'XK':
+  bank_code: 2!n
+  branch_code: 2!n
+  account_number: 10!n
+  check_digits: 2!c

--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -109,6 +109,11 @@
   account_number: 10!n
   check_digits: 2!n
 
+'EG':
+  bank_code: 4!c
+  branch_code: 4!n
+  account_number: 17!n
+
 'ES':
   account_number: 20!n
 

--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -327,6 +327,10 @@
   branch_code: 5!n
   account_number: 12!c
 
+'SV':
+  bank_code: 4!c
+  account_number: 20!n
+
 'TN':
   bank_code: 2!n
   branch_code: 3!n

--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -76,6 +76,11 @@
   bank_code: 5!n
   account_number: 12!c
 
+'CR':
+  reserved: 1!c
+  bank_code: 3!n
+  account_number: 14!n
+
 'CY':
   bank_code: 3!n
   branch_code: 5!n

--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -327,6 +327,10 @@
   reserved: 1!c
   account_number: 16!c
 
+'UA':
+  bank_code: 6!n
+  account_number: 19!n
+
 'VA':
   bank_code: 3!n
   account_number: 15!n

--- a/lib/iban-tools/conversion_rules.yml
+++ b/lib/iban-tools/conversion_rules.yml
@@ -66,6 +66,12 @@
   bank_code: 2!c
   account_number: 22!n
 
+'BR':
+  bank_code: 8!n
+  branch_code: 5!n
+  account_number: 10!n
+  account_type: 2!c
+
 'CH':
   bank_code: 5!n
   account_number: 12!c

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -68,6 +68,7 @@ module IBANTools
       'SI56191000000123438' => {bank_code: '19', branch_code: '100', account_number: '1234', check_digits: '38'},
       'SK3112000000198742637541' => {bank_code: '1200', account_prefix: '19', account_number: '8742637541'},
       'SM86U0322509800000000270100' => {check_char: 'U', bank_code: '3225', branch_code: '9800', account_number: '270100'},
+      'SV62CENR00000000000000700025' => {bank_code: 'CENR', account_number: '700025'},
       'TN5914207207100707129648' => {bank_code: '14', branch_code: '207', account_number: '207100707129648'},
       'TR330006100519786457841326' => {bank_code: '61', reserved: '0', account_number: '519786457841326'},
       'UA213223130000026007233566001' => {bank_code: '322313', account_number: '26007233566001'},

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -74,6 +74,7 @@ module IBANTools
       'UA213223130000026007233566001' => {bank_code: '322313', account_number: '26007233566001'},
       'VA59001123000012345678' => {bank_code: '1', account_number: '123000012345678'},
       'VG96VPVG0000012345678901' => {bank_code: 'VPVG', account_number: '12345678901'},
+      'XK051212012345678906' => { bank_code: '12', branch_code: '12', account_number: '123456789', check_digits: '6'},
     }
 
     describe '::local2iban' do

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -14,6 +14,7 @@ module IBANTools
       'BG80BNBG96611020345678' => {bank_code: 'BNBG', branch_code: '9661', account_type: '10', account_number: '20345678'},
       'BH67BMAG00001299123456' => {bank_code: 'BMAG', account_number: '1299123456'},
       'BJ66BJ0610100100144390000769' => {bank_code: 'BJ', account_number: '610100100144390000769'},
+      'BR1800360305000010009795493C1' => {bank_code: '360305', branch_code: '1', account_number: '9795493', account_type: 'C1'},
       'CH9300762011623852957' => {bank_code: '762', account_number: '11623852957'},
       'CY17002001280000001200527600' => {bank_code: '2', branch_code: '128', account_number: '1200527600'},
       'CZ6508000000192000145399' => {bank_code: '800', account_prefix: '19', account_number: '2000145399'},

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -23,6 +23,7 @@ module IBANTools
       'DK5000400440116243' => {bank_code: '40', account_number: '440116243'},
       'DO28BAGR00000001212453611324' => {bank_code: 'BAGR', account_number: '1212453611324'},
       'EE382200221020145685' => {bank_code: '22', branch_code: '0', account_number: '2210201456', check_digits: '85'},
+      'EG380019000500000000263180002' => { bank_code: '19', branch_code: '5', account_number: '263180002'},
       'ES9121000418450200051332' => {account_number: '21000418450200051332'},
       'FI2112345600000785' => {bank_code: '123456', account_number: '78', check_digit: '5'},
       'FO7630004440960235' => {bank_code: '3000', account_number: '444096023', check_digit: '5'},

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -16,6 +16,7 @@ module IBANTools
       'BJ66BJ0610100100144390000769' => {bank_code: 'BJ', account_number: '610100100144390000769'},
       'BR1800360305000010009795493C1' => {bank_code: '360305', branch_code: '1', account_number: '9795493', account_type: 'C1'},
       'CH9300762011623852957' => {bank_code: '762', account_number: '11623852957'},
+      'CR05015202001026284066' => {reserved: '0', bank_code: '152', account_number: '2001026284066'},
       'CY17002001280000001200527600' => {bank_code: '2', branch_code: '128', account_number: '1200527600'},
       'CZ6508000000192000145399' => {bank_code: '800', account_prefix: '19', account_number: '2000145399'},
       'DE89370400440532013000' => {blz: '37040044', account_number: '532013000'},

--- a/spec/iban-tools/conversion_spec.rb
+++ b/spec/iban-tools/conversion_spec.rb
@@ -68,6 +68,7 @@ module IBANTools
       'SM86U0322509800000000270100' => {check_char: 'U', bank_code: '3225', branch_code: '9800', account_number: '270100'},
       'TN5914207207100707129648' => {bank_code: '14', branch_code: '207', account_number: '207100707129648'},
       'TR330006100519786457841326' => {bank_code: '61', reserved: '0', account_number: '519786457841326'},
+      'UA213223130000026007233566001' => {bank_code: '322313', account_number: '26007233566001'},
       'VA59001123000012345678' => {bank_code: '1', account_number: '123000012345678'},
       'VG96VPVG0000012345678901' => {bank_code: 'VPVG', account_number: '12345678901'},
     }


### PR DESCRIPTION
Format definitions sourced from Wise

| Country code | Country | Source |
|--------|--------|--------|
| `BR` | Brazil | https://wise.com/us/iban/brazil |
| `CR` | Costa Rica | https://wise.com/us/iban/costa-rica |
| `EG` | Egypt | https://wise.com/us/iban/egypt |
| `SV` | El Salvador | https://wise.com/us/iban/el-salvador |
| `UA` | Ukraine | https://wise.com/us/iban/ukraine | 
| `XK` | Kosovo | https://wise.com/us/iban/kosovo | 


<details><summary>Remaining countries w/o conversion</summary> 

Comparing the keys in the YAML files, the following countries remain for conversion support
| Country code | Country |
|--------|--------|
| `BY` | Belarus |
| `CI` | Côte d'Ivoire (Ivory Coast) |
| `CV` | Cape Verde |
| `GA` | Gabon |
| `IQ` | Iraq | 
| `MA` | Morocco | 
| `MG` | Madagascar | 
| `SC` | Seychelles |

</details>  