### PR TITLE
CI: Use in-support Ruby versions in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.4
+          - 3.3
           - 3.2
-          - 3.1
-          - "3.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR drops all the non-supported EOL'd Ruby versions from the test matrix.

It _looks like_ there are requirements set up in Branch Protection or something, for this repo, so that it can't pass all checks when upgrading away from old Ruby versions.